### PR TITLE
Make the API be runnable in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:2.7-buster
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV USER=docker \
+    GROUP=docker \
+    UID=12345 \
+    GID=23456 \
+    HOME=/usr/src/app \
+    PYTHONUNBUFFERED=1 \
+    UWSGI_MODULE=api:app \
+    UWSGI_PROCESSES=1 \
+    UWSGI_THREADS=2 \
+    UWSGI_OFFLOAD_THREADS=2
+
+EXPOSE 5051
+EXPOSE 5678
+ENTRYPOINT [ "uwsgi", "--ini", "uwsgi.ini" ]

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -2,12 +2,6 @@ from flask import Flask
 import config
 
 app = Flask(__name__)
-
-# These are default settings, please, set them
-# before app.run customized to your own needs
-app.config['MONGO_HOST'] = config.MONGO_HOST
-app.config['MONGO_PORT'] = config.MONGO_PORT
-app.config['MONGO_DB'] = config.MONGO_DB
-app.config['REDIRECT'] = config.REDIRECT
+app.config.from_object(config)
 
 import api.views

--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,13 @@
+import json
+from os import environ
+
+DEBUG = environ.get('DEBUG', 'False') == 'True'
+MONGO_HOST = environ.get('MONGODB_HOST', 'localhost')
+MONGO_USER = environ.get('MONGODB_USER', None)
+MONGO_PASSWORD = environ.get('MONGODB_PASSWORD', None)
+MONGO_PORT = int(environ.get('MONGODB_PORT', 27017))
+MONGO_DB = environ.get('MONGODB_DATABASE', 'citybikes')
+PORT = int(environ.get('PORT', 5051))
+REDIRECT = json.loads(open('redirects.json', 'r').read())
+PREFIX = ''  # ie: /v2 for http://api.citybik.es/v2/networks
+ENDPOINT = environ.get('ENDPOINT', 'http://api.citybik.es')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3'
+services:
+  api:
+    image: citybikes/api
+    build: .
+    networks:
+      - citybikes
+    environment:
+      - MONGODB_HOST=mongodb
+      - DEBUG=True
+      - FLASK_ENV=development
+    env_file: .env
+    ports:
+      - "5051:5051"
+      - "5678:5678"
+    entrypoint:
+      - /usr/local/bin/python
+    command:
+      - "-m"
+      - "ptvsd"
+      - "--host"
+      - "0.0.0.0"
+      - "--port"
+      - "5678"
+      - "runserver.py"
+
+networks:
+  citybikes:
+    external:
+      # Use the network from citybikes-gyro stack
+      name: citybikes-gyro_citybikes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+ptvsd
+pymongo==2.9.5
+uwsgi

--- a/runserver.py
+++ b/runserver.py
@@ -5,4 +5,4 @@ app.config['MONGO_HOST'] = config.MONGO_HOST
 app.config['MONGO_PORT'] = config.MONGO_PORT
 app.config['MONGO_DB'] = config.MONGO_DB
 
-app.run(port = config.PORT, debug=config.DEBUG)
+app.run(port=config.PORT, debug=config.DEBUG, host='0.0.0.0', threaded=False, processes=1, use_reloader=False, use_debugger=False)

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,0 +1,69 @@
+# Taken from: https://github.com/nginxinc/kubernetes-ingress/issues/143#issuecomment-347814243
+[uwsgi]
+chdir = /usr/src/app
+uid = $(UID)
+gid = $(GID)
+module = $(UWSGI_MODULE)
+processes = $(UWSGI_PROCESSES)
+threads = $(UWSGI_THREADS)
+procname-prefix-spaced = uwsgi:$(UWSGI_MODULE)
+
+http-socket = :5051
+http-enable-proxy-protocol = 1
+http-auto-chunked = true
+http-keepalive = 75
+http-timeout = 75
+stats = :1717
+stats-http = 1
+offload-threads = $(UWSGI_OFFLOAD_THREADS)
+
+# Better startup/shutdown in docker:
+die-on-term = 1
+lazy-apps = 0
+
+vacuum = 1
+master = 1
+enable-threads = true
+thunder-lock = 1
+buffer-size = 65535
+
+# Logging
+log-x-forwarded-for = true
+#memory-report = true
+#disable-logging = true
+#log-slow = 200
+#log-date = true
+
+# Avoid errors on aborted client connections
+ignore-sigpipe = true
+ignore-write-errors = true
+disable-write-exception = true
+
+#listen=1000
+#max-fd=120000
+no-defer-accept = 1
+
+# Limits, Kill requests after 120 seconds
+harakiri = 120
+harakiri-verbose = true
+post-buffering = 4096
+
+# Custom headers
+add-header = X-Content-Type-Options: nosniff
+add-header = X-XSS-Protection: 1; mode=block
+add-header = Strict-Transport-Security: max-age=16070400
+add-header = Connection: Keep-Alive
+
+# Static file serving with caching headers and gzip
+static-map = /static=/usr/src/app/api/static
+static-gzip-dir = /usr/src/app/api/static
+static-expires = /usr/src/app/* 3600
+route-uri = ^/static/ addheader:Vary: Accept-Encoding
+error-route-uri = ^/static/ addheader:Cache-Control: no-cache
+
+# Cache stat() calls
+cache2 = name=statcalls,items=30
+static-cache-paths = 86400
+
+# Redirect http -> https
+route-if = equal:${HTTP_X_FORWARDED_PROTO};http redirect-permanent:https://${HTTP_HOST}${REQUEST_URI}


### PR DESCRIPTION
This is a continuation of the [Dockerization effort](https://github.com/eskerda/citybikes-gyro/pull/2).

The resulting image can be used for development (using Docker Compose) or in production. By default, it will start a [uWSGI](https://uwsgi-docs.readthedocs.io/en/latest/) with production-ready configuration.

Running it locally requires MongoDB which can be provided by the [`citybikes-gyro` stack](https://github.com/eskerda/citybikes-gyro/pull/2).