### PR TITLE
Add /near endpoint

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -31,7 +31,7 @@ class Document(object):
 
     def find(self, *args, **kwargs):
         results = self.collection.find(*args, **kwargs)
-	return map(lambda data: self.__class__(self.db, self.connection, data), results)
+        return map(lambda data: self.__class__(self.db, self.connection, data), results)
 
     def map_data(self):
         return self.data
@@ -47,16 +47,19 @@ class Station(Document):
     __collection__ = 'stations'
     __public_name__ = 'station'
 
-    def map_data(self, fields = None):
+    def map_data(self, fields=None, include_network_id=False):
         result = {
             'id': self._id,
             'name': self.name,
-            'latitude': self.latitude,
-            'longitude': self.longitude,
+            'latitude': self.location['coordinates'][0],
+            'longitude': self.location['coordinates'][1],
             'free_bikes': self.last_stat['bikes'],
             'empty_slots': self.last_stat['free'],
             'timestamp': getIsoTimestamp(self.last_stat['timestamp'], 'Z')
         }
+
+        if include_network_id:
+            result['network_id'] = self.network_id
 
         if 'extra' in self.last_stat:
             result['extra'] = self.last_stat['extra']
@@ -69,7 +72,7 @@ class Network(Document):
     stations = None
 
     def Stations(self):
-        sModel = Station(self.db, self.collection)
+        sModel = Station(self.db, self.connection)
         self.stations = sModel.find({'network_id': self._id})
 
     def map_data(self, fields = None):
@@ -97,6 +100,33 @@ class Network(Document):
                         if fields is None or key in fields
         }
 
+
+class Nearby(object):
+    def __init__(self, db, connection):
+        self.connection = connection
+        self.db = db
+
+    def map_data(self, fields=None):
+        return {
+            'near': map(lambda station: station.map_data(include_network_id=True), self.stations)
+        }
+
+    def near(self, latitude, longitude, distance):
+        sModel = Station(self.db, self.connection)
+        self.stations = sModel.find({
+            'location': {
+                '$near': {
+                    '$geometry': {
+                        'type': 'Point',
+                        'coordinates': [
+                            latitude,
+                            longitude
+                        ]
+                    },
+                    '$maxDistance': distance
+                }
+            }
+        })
 
 class GeneralPurposeEncoder(json.JSONEncoder):
     def default(self, obj):

--- a/api/models.py
+++ b/api/models.py
@@ -68,7 +68,7 @@ class Station(Document):
         if 'extra' in self.last_stat:
             result['extra'] = self.last_stat['extra']
 
-        if self.distance is not None:
+        if hasattr(self, 'distance'):
             result['distance'] = int(self.distance)
 
         return result

--- a/api/models.py
+++ b/api/models.py
@@ -55,8 +55,8 @@ class Station(Document):
         result = {
             'id': self._id,
             'name': self.name,
-            'latitude': self.location['coordinates'][0],
-            'longitude': self.location['coordinates'][1],
+            'longitude': self.location['coordinates'][0],
+            'latitude': self.location['coordinates'][1],
             'free_bikes': self.last_stat['bikes'],
             'empty_slots': self.last_stat['free'],
             'timestamp': getIsoTimestamp(self.last_stat['timestamp'], 'Z')
@@ -118,15 +118,15 @@ class Nearby(object):
             'near': map(lambda station: station.map_data(include_network_id=True), self.stations)
         }
 
-    def near(self, latitude, longitude, distance):
+    def near(self, longitude, latitude, distance):
         sModel = Station(self.db, self.connection)
         self.stations = sModel.aggregate([{
             '$geoNear': {
                 'near': {
                     'type': 'Point',
                     'coordinates': [
-                        latitude,
-                        longitude
+                        longitude,
+                        latitude
                     ]
                 },
                 'spherical': True,

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -35,7 +35,7 @@
     {...}
   ]
 }</pre>
-<pre id="net_resource">{{endpoint}}{{prefix}}/networks/network_id</pre>
+<pre id="net_resource">{{endpoint}}{{prefix}}/networks/<strong>network_id</strong></pre>
 <pre>
 {
   "network": {
@@ -64,6 +64,30 @@
   }
 }
 
+</pre>
+<pre id="near_resource">{{endpoint}}{{prefix}}/near?latitude=<strong>latitude</strong>&longitude=<strong>longitude</strong>&distance=<strong>distance</strong></pre>
+<h4>Parameters</h4>
+<ul>
+  <li><code><strong>latitude</strong></code> - latitude i.e. 48.83713368945151
+  <li><code><strong>longitude</strong></code> - longitude i.e. 2.374340554605615
+  <li><code><strong>distance</strong></code> - <em>(optional, default: 500)</em> maximum distance (in meters) from the coordinates
+</ul>
+<pre>
+{
+  "near": [
+    {
+        "name": "00903 - QUAI MAURIAC  / PONT DE BERCY",   /   <a href="http://en.wikipedia.org/wiki/UTC" target="_blank">UTC</a> Zulu timestamp of the last time
+        <b>"timestamp": "2014-04-14T12:10:17.622Z", </b> <-------/ the station was updated on our systems
+        "longitude": 2.374340554605615,                       
+        <b>"free_bikes": 1, </b>  <-------------------------- Available bikes
+        "latitude": 48.83713368945151, 
+        <b>"empty_slots": 19,</b>  <------------------------- Empty spaces
+        <b>"id": "f5a551a87eec15155d6409fe9d0ff8e2",</b> <--- Unique id for this station
+        <b>"network_id": "valenbisi",</b> <------------------ Network id
+    },
+    {...}
+  ]
+}
 </pre>
 <h2>Syntax</h2>
 <h3 id="filter">Field filtering</h3>

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -65,7 +65,7 @@
 }
 
 </pre>
-<pre id="near_resource">{{endpoint}}{{prefix}}/near?latitude=<strong>latitude</strong>&longitude=<strong>longitude</strong>&distance=<strong>distance</strong></pre>
+<pre id="near_resource">{{endpoint}}{{prefix}}/stations/near?latitude=<strong>latitude</strong>&longitude=<strong>longitude</strong>&distance=<strong>distance</strong></pre>
 <h4>Parameters</h4>
 <ul>
   <li><code><strong>latitude</strong></code> - latitude i.e. 48.83713368945151

--- a/api/views.py
+++ b/api/views.py
@@ -60,23 +60,23 @@ def get_network(network_id):
 @app.route('/near/', methods = ['GET'])
 @app.route('/near', methods = ['GET'])
 def get_near():
-    latitude = request.args.get('latitude', None)
     longitude = request.args.get('longitude', None)
+    latitude = request.args.get('latitude', None)
     distance = request.args.get('distance', 500)
 
-    if latitude is None or longitude is None:
+    if longitude is None or latitude is None:
         return jsonify({
-            'error': 'Please specify both latitude and longitude parameters'
+            'error': 'Please specify both longitude and latitude parameters'
         }), 400
     
     try:
-        latitude = float(latitude)
         longitude = float(longitude)
+        latitude = float(latitude)
         distance = int(distance)
     except ValueError:
         return jsonify({
-            'error': 'Latitude and longitude should be float and distance should be an integer'
+            'error': 'Longitude and latitude should be float and distance should be an integer'
         }), 400
 
-    Nearby.near(latitude, longitude, distance)
+    Nearby.near(longitude, latitude, distance)
     return jsonify(Nearby.map_data(app.fields))

--- a/api/views.py
+++ b/api/views.py
@@ -57,8 +57,8 @@ def get_network(network_id):
     }
     return jsonify(response)
 
-@app.route('/near/', methods = ['GET'])
-@app.route('/near', methods = ['GET'])
+@app.route('/stations/near/', methods=['GET'])
+@app.route('/stations/near', methods=['GET'])
 def get_near():
     longitude = request.args.get('longitude', None)
     latitude = request.args.get('latitude', None)


### PR DESCRIPTION
## Adds `/near` endpoint allowing to query stations close to a location

⚠️ This depends on [`citybikes-gyro/pull/3`](https://github.com/eskerda/citybikes-gyro/pull/3) and the database schema changes it introduces.

### Usage:

`/near?latitude=A&longitude=B&distance=C`

* `latitude` and `longitude` are coordinates to look around
* `distance` is an optional search radius in meters (default:500m)

This PR is currently deployed at [citybikes.gaiagreen.tech](https://citybikes.gaiagreen.tech/) to help out testing.